### PR TITLE
Publish messages functions

### DIFF
--- a/common/templates/context.go
+++ b/common/templates/context.go
@@ -174,6 +174,7 @@ type Context struct {
 	CurrentFrame *ContextFrame
 
 	IsExecedByLeaveMessage bool
+	IsExecedByJoinMessage  bool
 
 	IsExecedByEvalCC bool
 
@@ -187,7 +188,8 @@ type ContextFrame struct {
 	MentionHere     bool
 	MentionRoles    []int64
 
-	DelResponse bool
+	DelResponse     bool
+	PublishResponse bool
 
 	DelResponseDelay         int
 	EmebdsToSend             []*discordgo.MessageEmbed
@@ -514,6 +516,10 @@ func (c *Context) SendResponse(content string) (*discordgo.Message, error) {
 				}
 			}(c.CurrentFrame)
 		}
+
+		if c.CurrentFrame.PublishResponse && c.CurrentFrame.CS.Type == discordgo.ChannelTypeGuildNews {
+			common.BotSession.ChannelMessageCrosspost(m.ChannelID, m.ID)
+		}
 	}
 
 	return m, nil
@@ -584,6 +590,8 @@ func baseContextFuncs(c *Context) {
 	c.addContextFunc("editMessage", c.tmplEditMessage(true))
 	c.addContextFunc("editMessageNoEscape", c.tmplEditMessage(false))
 	c.addContextFunc("pinMessage", c.tmplPinMessage(false))
+	c.addContextFunc("publishMessage", c.tmplPublishMessage)
+	c.addContextFunc("publishResponse", c.tmplPublishResponse)
 	c.addContextFunc("sendDM", c.tmplSendDM)
 	c.addContextFunc("sendMessage", c.tmplSendMessage(true, false))
 	c.addContextFunc("sendMessageNoEscape", c.tmplSendMessage(false, false))

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -508,6 +508,52 @@ func (c *Context) tmplPinMessage(unpin bool) func(channel, msgID interface{}) (s
 	}
 }
 
+func (c *Context) tmplPublishMessage(channel, msgID interface{}) (string, error) {
+	// Too heavily ratelimited by Discord to allow rapid feeds to publish
+	if c.IsExecedByLeaveMessage || c.IsExecedByJoinMessage {
+		return "", nil
+	}
+
+	if c.IncreaseCheckGenericAPICall() {
+		return "", ErrTooManyAPICalls
+	}
+
+	if c.IncreaseCheckCallCounter("message_publish", 1) {
+		return "", ErrTooManyCalls
+	}
+
+	cID := c.ChannelArgNoDM(channel)
+	if cID == 0 {
+		return "", errors.New("unknown channel")
+	}
+	mID := ToInt64(msgID)
+
+	// Don't crosspost if the message has already been crossposted
+	msg, err := common.BotSession.ChannelMessage(cID, mID)
+	if err != nil {
+		return "", errors.New("message not found")
+	}
+	messageAlreadyCrossposted := msg.Flags&discordgo.MessageFlagsCrossPosted == discordgo.MessageFlagsCrossPosted
+	if messageAlreadyCrossposted {
+		return "", nil
+	}
+
+	_, err = common.BotSession.ChannelMessageCrosspost(cID, mID)
+	return "", err
+}
+
+func (c *Context) tmplPublishResponse() string {
+	// Too heavily ratelimited by Discord to allow rapid feeds to publish
+	if c.IsExecedByLeaveMessage || c.IsExecedByJoinMessage {
+		return ""
+	}
+
+	if c.CurrentFrame.CS.Type == discordgo.ChannelTypeGuildNews {
+		c.CurrentFrame.PublishResponse = true
+	}
+	return ""
+}
+
 func (c *Context) tmplMentionEveryone() string {
 	c.CurrentFrame.MentionEveryone = true
 	return "@everyone"

--- a/common/templates/context_funcs.go
+++ b/common/templates/context_funcs.go
@@ -511,7 +511,7 @@ func (c *Context) tmplPinMessage(unpin bool) func(channel, msgID interface{}) (s
 func (c *Context) tmplPublishMessage(channel, msgID interface{}) (string, error) {
 	// Too heavily ratelimited by Discord to allow rapid feeds to publish
 	if c.IsExecedByLeaveMessage || c.IsExecedByJoinMessage {
-		return "", nil
+		return "", errors.New("you cannot publish messages with a feed")
 	}
 
 	if c.IncreaseCheckGenericAPICall() {
@@ -542,16 +542,16 @@ func (c *Context) tmplPublishMessage(channel, msgID interface{}) (string, error)
 	return "", err
 }
 
-func (c *Context) tmplPublishResponse() string {
+func (c *Context) tmplPublishResponse() (string, error) {
 	// Too heavily ratelimited by Discord to allow rapid feeds to publish
 	if c.IsExecedByLeaveMessage || c.IsExecedByJoinMessage {
-		return ""
+		return "", errors.New("you cannot publish messages with a feed")
 	}
 
 	if c.CurrentFrame.CS.Type == discordgo.ChannelTypeGuildNews {
 		c.CurrentFrame.PublishResponse = true
 	}
-	return ""
+	return "", nil
 }
 
 func (c *Context) tmplMentionEveryone() string {

--- a/customcommands/bot.go
+++ b/customcommands/bot.go
@@ -115,6 +115,7 @@ type DelayedRunCCData struct {
 	UserKey interface{} `json:"user_key"`
 
 	IsExecedByLeaveMessage bool `json:"is_execed_by_leave_message"`
+	IsExecedByJoinMessage  bool `json:"is_execed_by_join_message"`
 }
 
 var cmdEvalCommand = &commands.YAGCommand{
@@ -414,6 +415,7 @@ func handleDelayedRunCC(evt *schEventsModels.ScheduledEvent, data interface{}) (
 	}
 
 	tmplCtx.IsExecedByLeaveMessage = dataCast.IsExecedByLeaveMessage
+	tmplCtx.IsExecedByJoinMessage = dataCast.IsExecedByJoinMessage
 
 	// decode userdata
 	if len(dataCast.UserData) > 0 {

--- a/customcommands/tmplextensions.go
+++ b/customcommands/tmplextensions.go
@@ -223,6 +223,7 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 			newCtx.Data["ExecData"] = data
 			newCtx.Data["StackDepth"] = currentStackDepth + 1
 			newCtx.IsExecedByLeaveMessage = ctx.IsExecedByLeaveMessage
+			newCtx.IsExecedByJoinMessage = ctx.IsExecedByJoinMessage
 
 			go ExecuteCustomCommand(cmd, newCtx)
 			return "", nil
@@ -236,6 +237,7 @@ func tmplRunCC(ctx *templates.Context) interface{} {
 			Message: ctx.Msg,
 
 			IsExecedByLeaveMessage: ctx.IsExecedByLeaveMessage,
+			IsExecedByJoinMessage:  ctx.IsExecedByJoinMessage,
 		}
 
 		// embed data using msgpack to include type information
@@ -310,6 +312,7 @@ func tmplScheduleUniqueCC(ctx *templates.Context) interface{} {
 			UserKey: stringedKey,
 
 			IsExecedByLeaveMessage: ctx.IsExecedByLeaveMessage,
+			IsExecedByJoinMessage:  ctx.IsExecedByJoinMessage,
 		}
 
 		// embed data using msgpack to include type information

--- a/lib/discordgo/endpoints.go
+++ b/lib/discordgo/endpoints.go
@@ -114,6 +114,7 @@ var (
 	EndpointChannelMessagesBulkDelete = func(cID int64) string { return "" }
 	EndpointChannelMessagesPins       = func(cID int64) string { return "" }
 	EndpointChannelMessagePin         = func(cID, mID int64) string { return "" }
+	EndpointChannelMessageCrosspost   = func(cID, mID int64) string { return "" }
 
 	EndpointGroupIcon = func(cID int64, hash string) string { return "" }
 
@@ -288,6 +289,7 @@ func CreateEndpoints(base string) {
 	EndpointChannelMessagesBulkDelete = func(cID int64) string { return EndpointChannel(cID) + "/messages/bulk-delete" }
 	EndpointChannelMessagesPins = func(cID int64) string { return EndpointChannel(cID) + "/pins" }
 	EndpointChannelMessagePin = func(cID, mID int64) string { return EndpointChannel(cID) + "/pins/" + StrID(mID) }
+	EndpointChannelMessageCrosspost = func(cID, mID int64) string { return EndpointChannel(cID) + "/messages/" + StrID(mID) + "/crosspost" }
 
 	EndpointGroupIcon = func(cID int64, hash string) string { return EndpointCDNChannelIcons + StrID(cID) + "/" + hash + ".png" }
 

--- a/lib/discordgo/message.go
+++ b/lib/discordgo/message.go
@@ -153,6 +153,11 @@ type Message struct {
 	// This means responses to message component interactions do not include this property,
 	// instead including a MessageReference, as components exist on preexisting messages.
 	Interaction *MessageInteraction `json:"interaction"`
+
+	// The flags of the message, which describe extra features of a message.
+	// This is a combination of bit masks; the presence of a certain permission can
+	// be checked by performing a bitwise AND between this int and the flag.
+	Flags MessageFlags `json:"flags"`
 }
 
 func (m *Message) GetGuildID() int64 {

--- a/lib/discordgo/restapi.go
+++ b/lib/discordgo/restapi.go
@@ -1908,6 +1908,23 @@ func (s *Session) ChannelPermissionDelete(channelID, targetID int64) (err error)
 	return
 }
 
+// ChannelMessageCrosspost cross posts a message in a news channel to followers
+// of the channel
+// channelID   : The ID of a Channel
+// messageID   : The ID of a Message
+func (s *Session) ChannelMessageCrosspost(channelID, messageID int64) (st *Message, err error) {
+
+	endpoint := EndpointChannelMessageCrosspost(channelID, messageID)
+
+	body, err := s.RequestWithBucketID("POST", endpoint, nil, nil, endpoint)
+	if err != nil {
+		return
+	}
+
+	err = unmarshal(body, &st)
+	return
+}
+
 // ------------------------------------------------------------------------------------------------
 // Functions specific to Discord Invites
 // ------------------------------------------------------------------------------------------------

--- a/lib/discordgo/structs.go
+++ b/lib/discordgo/structs.go
@@ -1292,7 +1292,8 @@ const (
 	ErrCodeMaximumGuildRolesReached = 30005
 	ErrCodeTooManyReactions         = 30010
 
-	ErrCodeUnauthorized = 40001
+	ErrCodeUnauthorized              = 40001
+	ErrCodeMessageAlreadyCrossposted = 40033
 
 	ErrCodeMissingAccess                             = 50001
 	ErrCodeInvalidAccountType                        = 50002

--- a/lib/template/parse/parse_test.go
+++ b/lib/template/parse/parse_test.go
@@ -741,6 +741,8 @@ var funcs = map[string]interface{}{
 	"print":                     func() interface{} { return nil },
 	"printf":                    func() interface{} { return nil },
 	"println":                   func() interface{} { return nil },
+	"publishMessage":            func() interface{} { return nil },
+	"publishResponse":           func() interface{} { return nil },
 	"randInt":                   func() interface{} { return nil },
 	"reFind":                    func() interface{} { return nil },
 	"reFindAll":                 func() interface{} { return nil },

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -145,10 +145,6 @@ func sendTemplate(gs *dstate.GuildSet, cs *dstate.ChannelState, tmpl string, ms 
 	if !enableSendDM {
 		disableFuncs = []string{"sendDM"}
 	}
-	// Publishing functions are too heavily ratelimited by Discord to allow
-	// rapid feeds to publish
-	disableFuncs = append(disableFuncs, "publishMessage")
-	disableFuncs = append(disableFuncs, "publishResponse")
 	ctx.DisabledContextFuncs = disableFuncs
 
 	msg, err := ctx.Execute(tmpl)

--- a/notifications/plugin_bot.go
+++ b/notifications/plugin_bot.go
@@ -147,7 +147,8 @@ func sendTemplate(gs *dstate.GuildSet, cs *dstate.ChannelState, tmpl string, ms 
 	}
 	// Publishing functions are too heavily ratelimited by Discord to allow
 	// rapid feeds to publish
-	disableFuncs = []string{"publishMessage", "publishResponse"}
+	disableFuncs = append(disableFuncs, "publishMessage")
+	disableFuncs = append(disableFuncs, "publishResponse")
 	ctx.DisabledContextFuncs = disableFuncs
 
 	msg, err := ctx.Execute(tmpl)


### PR DESCRIPTION
This pr adds message publishing functionality to custom commands. It adds two new functions, `publishMessage`, and `publishResponse`.

`publishMessage` channel messageID
Publishes a message by its ID in given announcement channel. channel can be either its ID, name or nil for triggering channel. Can be called once. This function will not work for leave or join messages.

`publishResponse`
Publishes the response when executed in an announcement channel. This function will not work for leave or join messages.

Both functions will validate the channel is an announcement channel, and check if the message is not already published (in the case of publishMessage) before attempting to publish. If either of these events are false, the function fails silently. This is intentional, but of course up for debate. If either function is executed in a join or leave feed, it will silently fail, similarly to `sendDM` in a leave feed. This is intentional, as Discord's current rate limit for published messages is 10 per channel per hour, so fast feeds such as these would be too frequent.

https://github.com/botlabs-gg/yagpdb/assets/110698921/58c11ce4-6299-4b40-a190-6e0e425a147f

https://github.com/botlabs-gg/yagpdb/assets/110698921/75ebe4c5-8265-4db2-a567-61de8aa56e7f

https://github.com/botlabs-gg/yagpdb/assets/110698921/d877afe0-d4e4-46bd-b311-c5da62ea748c