### PR TITLE
customcommands/publicity: switch to hashed ids

### DIFF
--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -54,6 +54,9 @@
 
 
                     {{$guild := .ActiveGuild.ID}}
+                    {{if .PublicAccess}}
+                        {{$guild = 0}}
+                    {{end}}
                     {{$g := .ActiveGuild}}
                     {{$dot := .}}
                     <form class="form-horizontal" method="post"
@@ -205,14 +208,16 @@
                                                 placeholder="" value="{{call $dot.GetCCInterval .CC}}">
                                         </div>
                                     </div>
-                                    <div class="col-sm-8">
+                                    {{if not .PublicAccess}}
+                                    <div class="col-sm-8 public-hidden">
                                         <div class="form-group">
                                             <label>Channel</label>
-                                            <select id="time-trigger-channel" name="context_channel" class="form-control public-disabled">
+                                            <select id="time-trigger-channel" name="context_channel" class="form-control">
                                                 {{textChannelOptions $g.Channels .CC.ContextChannel true "None"}}
                                             </select>
                                         </div>
                                     </div>
+                                    {{end}}
                                 </div>
                                 <div class="row">
                                     <div class="col-sm-6">
@@ -267,6 +272,7 @@
                                     <p>An optional name that can be used to identify the command.</p>
                                 </div>
                             </div>
+                            {{if not .PublicAccess}}
                              <div class="col-sm-4 public-hidden">
                                 <div class="form-group">
                                     <br/>
@@ -278,6 +284,8 @@
                                         href="#cc-share-modal">Share this Command</a>
                                 </div>
                             </div>
+                            </div>
+                            {{end}}
                         </div>
                         <div class="row mb-2">
                             <div class="col-lg-12">
@@ -328,6 +336,7 @@
                                 </div>
                             </div>
                         </div>
+                        {{if not .PublicAccess}}
                         <div class="row public-hidden">
                             <div class="col-sm-6">
                                 <div class="form-group">
@@ -410,6 +419,7 @@
                                 </select>
                             </div>
                         </div>
+                        {{end}}
 
                         <div class="row mt-4 public-hidden">
                             <div class="col">

--- a/customcommands/assets/customcommands-editcmd.html
+++ b/customcommands/assets/customcommands-editcmd.html
@@ -59,14 +59,14 @@
                     {{end}}
                     {{$g := .ActiveGuild}}
                     {{$dot := .}}
-                    <form class="form-horizontal" method="post"
+                    <form id="main-form" class="form-horizontal" method="post"
                         action="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/update" data-async-form>
                         <button type="submit" class="hidden"
                             formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/update"
                             data-async-form-alertsonly></button>
 
                         <h2 class="card-title">
-                            #{{.CC.LocalID}} -
+                            {{if not .PublicAccess}}#{{.CC.LocalID}} -{{end}}
                             {{index .CCTriggerTypes .CC.TriggerType}}{{if and (ne .CC.TriggerType 5) (ne .CC.TriggerType 6)}}:
                             <span
                                 class="cc-text-trigger-span">{{.CC.TextTrigger}}</span>{{else if ne .CC.TriggerType 6}}:
@@ -278,12 +278,21 @@
                                     <br/>
                                     <label> Command Enabled?</label>
                                     {{checkbox "is_enabled" "is_enabled" "Enables or Disables the command" (not .CC.Disabled)}}
-                                    <label> Public?</label>
-                                    {{checkbox "public" "public" "Allows non-members to view the CC with a link" .CC.Public}}
-                                    <a class="mb-1 mt-1 mr-1 modal-basic btn btn-info btn-md"
-                                        href="#cc-share-modal">Share this Command</a>
+                                    <label> Allow Imports?</label>
+                                    {{checkbox "public" "public" "Anyone with an import link can copy this custom command into their server." .CC.Public}}
+                                    {{if eq .PublicLink ""}}
+                                    <button type="submit" class="btn btn-tertriary btn-md" title="This will trigger this custom command immediately"
+                                    form="main-form" formaction="/manage/{{$guild}}/customcommands/commands/{{.CC.LocalID}}/update_and_share">Create
+                                    import link</button>
+                                    {{else}}
+                                    <a class="mb-1 mt-1 mr-1 modal-basic btn btn-quaternary btn-md"
+                                        href="#cc-share-modal">Copy Import Link</a>
+                                        <div class="col-auto">
+                                            <h4>Import count</h4>
+                                            <p><code>{{.CC.ImportCount}}</code></p>
+                                        </div>
+                                    {{end}}
                                 </div>
-                            </div>
                             </div>
                             {{end}}
                         </div>
@@ -496,12 +505,13 @@
 <div id="cc-share-modal" class="modal-block modal-header-color modal-block-info mfp-hide">
     <section class="card">
         <header class="card-header">
-            <h2 class="card-title">Share Custom Command</h2>
+            <h2 class="card-title">Copy Import Link</h2>
         </header>
         <div class="card-body">
             <div class="modal-wrapper">
                 <div class="modal-text">
-                    <p class="help-block">To share custom command #<code>{{.CC.LocalID}}</code>, copy the link below.
+                    <p class="help-block">To share custom command #<code>{{.CC.LocalID}}</code>, and allow users to
+                    import it, copy the link below.
                     </p>
                     <br>
                     <input type="text" id="public-link" class="form-control" name="Public Link" value="{{.PublicLink}}" readonly>

--- a/customcommands/customcommands.go
+++ b/customcommands/customcommands.go
@@ -122,6 +122,7 @@ type CustomCommand struct {
 	Name          string   `json:"name" schema:"name" valid:",0,100"`
 	IsEnabled     bool     `json:"is_enabled" schema:"is_enabled"`
 	Public        bool     `json:"public" schema:"public"`
+	PublicID      string   `json:"public_id" schema:"public_id"`
 
 	ContextChannel int64 `schema:"context_channel" valid:"channel,true"`
 
@@ -195,6 +196,7 @@ func (cc *CustomCommand) ToDBModel() *models.CustomCommand {
 		TextTrigger:              cc.Trigger,
 		TextTriggerCaseSensitive: cc.CaseSensitive,
 		Public:                   cc.Public,
+		PublicID:                 cc.PublicID,
 
 		Channels:              cc.Channels,
 		ChannelsWhitelistMode: cc.RequireChannels,

--- a/customcommands/models/custom_command_groups.go
+++ b/customcommands/models/custom_command_groups.go
@@ -31,7 +31,6 @@ type CustomCommandGroup struct {
 	IgnoreChannels    types.Int64Array `boil:"ignore_channels" json:"ignore_channels,omitempty" toml:"ignore_channels" yaml:"ignore_channels,omitempty"`
 	WhitelistRoles    types.Int64Array `boil:"whitelist_roles" json:"whitelist_roles,omitempty" toml:"whitelist_roles" yaml:"whitelist_roles,omitempty"`
 	WhitelistChannels types.Int64Array `boil:"whitelist_channels" json:"whitelist_channels,omitempty" toml:"whitelist_channels" yaml:"whitelist_channels,omitempty"`
-	Github            string           `boil:"github" json:"github" toml:"github" yaml:"github"`
 
 	R *customCommandGroupR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L customCommandGroupL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -45,7 +44,6 @@ var CustomCommandGroupColumns = struct {
 	IgnoreChannels    string
 	WhitelistRoles    string
 	WhitelistChannels string
-	Github            string
 }{
 	ID:                "id",
 	GuildID:           "guild_id",
@@ -54,7 +52,6 @@ var CustomCommandGroupColumns = struct {
 	IgnoreChannels:    "ignore_channels",
 	WhitelistRoles:    "whitelist_roles",
 	WhitelistChannels: "whitelist_channels",
-	Github:            "github",
 }
 
 // Generated where
@@ -122,7 +119,6 @@ var CustomCommandGroupWhere = struct {
 	IgnoreChannels    whereHelpertypes_Int64Array
 	WhitelistRoles    whereHelpertypes_Int64Array
 	WhitelistChannels whereHelpertypes_Int64Array
-	Github            whereHelperstring
 }{
 	ID:                whereHelperint64{field: "\"custom_command_groups\".\"id\""},
 	GuildID:           whereHelperint64{field: "\"custom_command_groups\".\"guild_id\""},
@@ -131,7 +127,6 @@ var CustomCommandGroupWhere = struct {
 	IgnoreChannels:    whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"ignore_channels\""},
 	WhitelistRoles:    whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"whitelist_roles\""},
 	WhitelistChannels: whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"whitelist_channels\""},
-	Github:            whereHelperstring{field: "\"custom_command_groups\".\"github\""},
 }
 
 // CustomCommandGroupRels is where relationship names are stored.
@@ -155,9 +150,9 @@ func (*customCommandGroupR) NewStruct() *customCommandGroupR {
 type customCommandGroupL struct{}
 
 var (
-	customCommandGroupAllColumns            = []string{"id", "guild_id", "name", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels", "github"}
+	customCommandGroupAllColumns            = []string{"id", "guild_id", "name", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels"}
 	customCommandGroupColumnsWithoutDefault = []string{"guild_id", "name", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels"}
-	customCommandGroupColumnsWithDefault    = []string{"id", "github"}
+	customCommandGroupColumnsWithDefault    = []string{"id"}
 	customCommandGroupPrimaryKeyColumns     = []string{"id"}
 )
 

--- a/customcommands/models/custom_command_groups.go
+++ b/customcommands/models/custom_command_groups.go
@@ -31,6 +31,7 @@ type CustomCommandGroup struct {
 	IgnoreChannels    types.Int64Array `boil:"ignore_channels" json:"ignore_channels,omitempty" toml:"ignore_channels" yaml:"ignore_channels,omitempty"`
 	WhitelistRoles    types.Int64Array `boil:"whitelist_roles" json:"whitelist_roles,omitempty" toml:"whitelist_roles" yaml:"whitelist_roles,omitempty"`
 	WhitelistChannels types.Int64Array `boil:"whitelist_channels" json:"whitelist_channels,omitempty" toml:"whitelist_channels" yaml:"whitelist_channels,omitempty"`
+	Github            string           `boil:"github" json:"github" toml:"github" yaml:"github"`
 
 	R *customCommandGroupR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L customCommandGroupL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -44,6 +45,7 @@ var CustomCommandGroupColumns = struct {
 	IgnoreChannels    string
 	WhitelistRoles    string
 	WhitelistChannels string
+	Github            string
 }{
 	ID:                "id",
 	GuildID:           "guild_id",
@@ -52,6 +54,7 @@ var CustomCommandGroupColumns = struct {
 	IgnoreChannels:    "ignore_channels",
 	WhitelistRoles:    "whitelist_roles",
 	WhitelistChannels: "whitelist_channels",
+	Github:            "github",
 }
 
 // Generated where
@@ -119,6 +122,7 @@ var CustomCommandGroupWhere = struct {
 	IgnoreChannels    whereHelpertypes_Int64Array
 	WhitelistRoles    whereHelpertypes_Int64Array
 	WhitelistChannels whereHelpertypes_Int64Array
+	Github            whereHelperstring
 }{
 	ID:                whereHelperint64{field: "\"custom_command_groups\".\"id\""},
 	GuildID:           whereHelperint64{field: "\"custom_command_groups\".\"guild_id\""},
@@ -127,6 +131,7 @@ var CustomCommandGroupWhere = struct {
 	IgnoreChannels:    whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"ignore_channels\""},
 	WhitelistRoles:    whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"whitelist_roles\""},
 	WhitelistChannels: whereHelpertypes_Int64Array{field: "\"custom_command_groups\".\"whitelist_channels\""},
+	Github:            whereHelperstring{field: "\"custom_command_groups\".\"github\""},
 }
 
 // CustomCommandGroupRels is where relationship names are stored.
@@ -150,9 +155,9 @@ func (*customCommandGroupR) NewStruct() *customCommandGroupR {
 type customCommandGroupL struct{}
 
 var (
-	customCommandGroupAllColumns            = []string{"id", "guild_id", "name", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels"}
+	customCommandGroupAllColumns            = []string{"id", "guild_id", "name", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels", "github"}
 	customCommandGroupColumnsWithoutDefault = []string{"guild_id", "name", "ignore_roles", "ignore_channels", "whitelist_roles", "whitelist_channels"}
-	customCommandGroupColumnsWithDefault    = []string{"id"}
+	customCommandGroupColumnsWithDefault    = []string{"id", "github"}
 	customCommandGroupPrimaryKeyColumns     = []string{"id"}
 )
 

--- a/customcommands/models/custom_commands.go
+++ b/customcommands/models/custom_commands.go
@@ -53,6 +53,7 @@ type CustomCommand struct {
 	GithubResponse            bool              `boil:"github_response" json:"github_response" toml:"github_response" yaml:"github_response"`
 	Public                    bool              `boil:"public" json:"public" toml:"public" yaml:"public"`
 	PublicID                  string            `boil:"public_id" json:"public_id" toml:"public_id" yaml:"public_id"`
+	ImportCount               int               `boil:"import_count" json:"import_count" toml:"import_count" yaml:"import_count"`
 
 	R *customCommandR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L customCommandL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -87,6 +88,7 @@ var CustomCommandColumns = struct {
 	GithubResponse            string
 	Public                    string
 	PublicID                  string
+	ImportCount               string
 }{
 	LocalID:                   "local_id",
 	GuildID:                   "guild_id",
@@ -116,6 +118,7 @@ var CustomCommandColumns = struct {
 	GithubResponse:            "github_response",
 	Public:                    "public",
 	PublicID:                  "public_id",
+	ImportCount:               "import_count",
 }
 
 // Generated where
@@ -280,6 +283,7 @@ var CustomCommandWhere = struct {
 	GithubResponse            whereHelperbool
 	Public                    whereHelperbool
 	PublicID                  whereHelperstring
+	ImportCount               whereHelperint
 }{
 	LocalID:                   whereHelperint64{field: "\"custom_commands\".\"local_id\""},
 	GuildID:                   whereHelperint64{field: "\"custom_commands\".\"guild_id\""},
@@ -309,6 +313,7 @@ var CustomCommandWhere = struct {
 	GithubResponse:            whereHelperbool{field: "\"custom_commands\".\"github_response\""},
 	Public:                    whereHelperbool{field: "\"custom_commands\".\"public\""},
 	PublicID:                  whereHelperstring{field: "\"custom_commands\".\"public_id\""},
+	ImportCount:               whereHelperint{field: "\"custom_commands\".\"import_count\""},
 }
 
 // CustomCommandRels is where relationship names are stored.
@@ -332,9 +337,9 @@ func (*customCommandR) NewStruct() *customCommandR {
 type customCommandL struct{}
 
 var (
-	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "github_response", "public", "public_id"}
+	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "github_response", "public", "public_id", "import_count"}
 	customCommandColumnsWithoutDefault = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "last_error_time", "name"}
-	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "github_response", "public", "public_id"}
+	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "github_response", "public", "public_id", "import_count"}
 	customCommandPrimaryKeyColumns     = []string{"guild_id", "local_id"}
 )
 

--- a/customcommands/models/custom_commands.go
+++ b/customcommands/models/custom_commands.go
@@ -50,7 +50,6 @@ type CustomCommand struct {
 	Disabled                  bool              `boil:"disabled" json:"disabled" toml:"disabled" yaml:"disabled"`
 	TriggerOnEdit             bool              `boil:"trigger_on_edit" json:"trigger_on_edit" toml:"trigger_on_edit" yaml:"trigger_on_edit"`
 	Name                      null.String       `boil:"name" json:"name,omitempty" toml:"name" yaml:"name,omitempty"`
-	GithubResponse            bool              `boil:"github_response" json:"github_response" toml:"github_response" yaml:"github_response"`
 	Public                    bool              `boil:"public" json:"public" toml:"public" yaml:"public"`
 	PublicID                  string            `boil:"public_id" json:"public_id" toml:"public_id" yaml:"public_id"`
 	ImportCount               int               `boil:"import_count" json:"import_count" toml:"import_count" yaml:"import_count"`
@@ -85,7 +84,6 @@ var CustomCommandColumns = struct {
 	Disabled                  string
 	TriggerOnEdit             string
 	Name                      string
-	GithubResponse            string
 	Public                    string
 	PublicID                  string
 	ImportCount               string
@@ -115,7 +113,6 @@ var CustomCommandColumns = struct {
 	Disabled:                  "disabled",
 	TriggerOnEdit:             "trigger_on_edit",
 	Name:                      "name",
-	GithubResponse:            "github_response",
 	Public:                    "public",
 	PublicID:                  "public_id",
 	ImportCount:               "import_count",
@@ -280,7 +277,6 @@ var CustomCommandWhere = struct {
 	Disabled                  whereHelperbool
 	TriggerOnEdit             whereHelperbool
 	Name                      whereHelpernull_String
-	GithubResponse            whereHelperbool
 	Public                    whereHelperbool
 	PublicID                  whereHelperstring
 	ImportCount               whereHelperint
@@ -310,7 +306,6 @@ var CustomCommandWhere = struct {
 	Disabled:                  whereHelperbool{field: "\"custom_commands\".\"disabled\""},
 	TriggerOnEdit:             whereHelperbool{field: "\"custom_commands\".\"trigger_on_edit\""},
 	Name:                      whereHelpernull_String{field: "\"custom_commands\".\"name\""},
-	GithubResponse:            whereHelperbool{field: "\"custom_commands\".\"github_response\""},
 	Public:                    whereHelperbool{field: "\"custom_commands\".\"public\""},
 	PublicID:                  whereHelperstring{field: "\"custom_commands\".\"public_id\""},
 	ImportCount:               whereHelperint{field: "\"custom_commands\".\"import_count\""},
@@ -337,9 +332,9 @@ func (*customCommandR) NewStruct() *customCommandR {
 type customCommandL struct{}
 
 var (
-	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "github_response", "public", "public_id", "import_count"}
+	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "public", "public_id", "import_count"}
 	customCommandColumnsWithoutDefault = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "last_error_time", "name"}
-	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "github_response", "public", "public_id", "import_count"}
+	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "public", "public_id", "import_count"}
 	customCommandPrimaryKeyColumns     = []string{"guild_id", "local_id"}
 )
 

--- a/customcommands/models/custom_commands.go
+++ b/customcommands/models/custom_commands.go
@@ -50,6 +50,7 @@ type CustomCommand struct {
 	Disabled                  bool              `boil:"disabled" json:"disabled" toml:"disabled" yaml:"disabled"`
 	TriggerOnEdit             bool              `boil:"trigger_on_edit" json:"trigger_on_edit" toml:"trigger_on_edit" yaml:"trigger_on_edit"`
 	Name                      null.String       `boil:"name" json:"name,omitempty" toml:"name" yaml:"name,omitempty"`
+	GithubResponse            bool              `boil:"github_response" json:"github_response" toml:"github_response" yaml:"github_response"`
 	Public                    bool              `boil:"public" json:"public" toml:"public" yaml:"public"`
 	PublicID                  string            `boil:"public_id" json:"public_id" toml:"public_id" yaml:"public_id"`
 
@@ -83,6 +84,7 @@ var CustomCommandColumns = struct {
 	Disabled                  string
 	TriggerOnEdit             string
 	Name                      string
+	GithubResponse            string
 	Public                    string
 	PublicID                  string
 }{
@@ -111,6 +113,7 @@ var CustomCommandColumns = struct {
 	Disabled:                  "disabled",
 	TriggerOnEdit:             "trigger_on_edit",
 	Name:                      "name",
+	GithubResponse:            "github_response",
 	Public:                    "public",
 	PublicID:                  "public_id",
 }
@@ -274,6 +277,7 @@ var CustomCommandWhere = struct {
 	Disabled                  whereHelperbool
 	TriggerOnEdit             whereHelperbool
 	Name                      whereHelpernull_String
+	GithubResponse            whereHelperbool
 	Public                    whereHelperbool
 	PublicID                  whereHelperstring
 }{
@@ -302,6 +306,7 @@ var CustomCommandWhere = struct {
 	Disabled:                  whereHelperbool{field: "\"custom_commands\".\"disabled\""},
 	TriggerOnEdit:             whereHelperbool{field: "\"custom_commands\".\"trigger_on_edit\""},
 	Name:                      whereHelpernull_String{field: "\"custom_commands\".\"name\""},
+	GithubResponse:            whereHelperbool{field: "\"custom_commands\".\"github_response\""},
 	Public:                    whereHelperbool{field: "\"custom_commands\".\"public\""},
 	PublicID:                  whereHelperstring{field: "\"custom_commands\".\"public_id\""},
 }
@@ -327,9 +332,9 @@ func (*customCommandR) NewStruct() *customCommandR {
 type customCommandL struct{}
 
 var (
-	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "public", "public_id"}
+	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "github_response", "public", "public_id"}
 	customCommandColumnsWithoutDefault = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "last_error_time", "name"}
-	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "public", "public_id"}
+	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "github_response", "public", "public_id"}
 	customCommandPrimaryKeyColumns     = []string{"guild_id", "local_id"}
 )
 

--- a/customcommands/models/custom_commands.go
+++ b/customcommands/models/custom_commands.go
@@ -48,9 +48,10 @@ type CustomCommand struct {
 	RunCount                  int               `boil:"run_count" json:"run_count" toml:"run_count" yaml:"run_count"`
 	ShowErrors                bool              `boil:"show_errors" json:"show_errors" toml:"show_errors" yaml:"show_errors"`
 	Disabled                  bool              `boil:"disabled" json:"disabled" toml:"disabled" yaml:"disabled"`
-	Name                      null.String       `boil:"name" json:"name,omitempty" toml:"name" yaml:"name,omitempty"`
 	TriggerOnEdit             bool              `boil:"trigger_on_edit" json:"trigger_on_edit" toml:"trigger_on_edit" yaml:"trigger_on_edit"`
+	Name                      null.String       `boil:"name" json:"name,omitempty" toml:"name" yaml:"name,omitempty"`
 	Public                    bool              `boil:"public" json:"public" toml:"public" yaml:"public"`
+	PublicID                  string            `boil:"public_id" json:"public_id" toml:"public_id" yaml:"public_id"`
 
 	R *customCommandR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L customCommandL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -80,9 +81,10 @@ var CustomCommandColumns = struct {
 	RunCount                  string
 	ShowErrors                string
 	Disabled                  string
-	Name                      string
 	TriggerOnEdit             string
+	Name                      string
 	Public                    string
+	PublicID                  string
 }{
 	LocalID:                   "local_id",
 	GuildID:                   "guild_id",
@@ -107,9 +109,10 @@ var CustomCommandColumns = struct {
 	RunCount:                  "run_count",
 	ShowErrors:                "show_errors",
 	Disabled:                  "disabled",
-	Name:                      "name",
 	TriggerOnEdit:             "trigger_on_edit",
+	Name:                      "name",
 	Public:                    "public",
+	PublicID:                  "public_id",
 }
 
 // Generated where
@@ -269,9 +272,10 @@ var CustomCommandWhere = struct {
 	RunCount                  whereHelperint
 	ShowErrors                whereHelperbool
 	Disabled                  whereHelperbool
-	Name                      whereHelpernull_String
 	TriggerOnEdit             whereHelperbool
+	Name                      whereHelpernull_String
 	Public                    whereHelperbool
+	PublicID                  whereHelperstring
 }{
 	LocalID:                   whereHelperint64{field: "\"custom_commands\".\"local_id\""},
 	GuildID:                   whereHelperint64{field: "\"custom_commands\".\"guild_id\""},
@@ -296,9 +300,10 @@ var CustomCommandWhere = struct {
 	RunCount:                  whereHelperint{field: "\"custom_commands\".\"run_count\""},
 	ShowErrors:                whereHelperbool{field: "\"custom_commands\".\"show_errors\""},
 	Disabled:                  whereHelperbool{field: "\"custom_commands\".\"disabled\""},
-	Name:                      whereHelpernull_String{field: "\"custom_commands\".\"name\""},
 	TriggerOnEdit:             whereHelperbool{field: "\"custom_commands\".\"trigger_on_edit\""},
+	Name:                      whereHelpernull_String{field: "\"custom_commands\".\"name\""},
 	Public:                    whereHelperbool{field: "\"custom_commands\".\"public\""},
+	PublicID:                  whereHelperstring{field: "\"custom_commands\".\"public_id\""},
 }
 
 // CustomCommandRels is where relationship names are stored.
@@ -322,9 +327,9 @@ func (*customCommandR) NewStruct() *customCommandR {
 type customCommandL struct{}
 
 var (
-	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "name", "trigger_on_edit", "public"}
+	customCommandAllColumns            = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "context_channel", "reaction_trigger_mode", "last_error", "last_error_time", "run_count", "show_errors", "disabled", "trigger_on_edit", "name", "public", "public_id"}
 	customCommandColumnsWithoutDefault = []string{"local_id", "guild_id", "group_id", "trigger_type", "text_trigger", "text_trigger_case_sensitive", "time_trigger_interval", "time_trigger_excluding_days", "time_trigger_excluding_hours", "last_run", "next_run", "responses", "channels", "channels_whitelist_mode", "roles", "roles_whitelist_mode", "last_error_time", "name"}
-	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "public"}
+	customCommandColumnsWithDefault    = []string{"context_channel", "reaction_trigger_mode", "last_error", "run_count", "show_errors", "disabled", "trigger_on_edit", "public", "public_id"}
 	customCommandPrimaryKeyColumns     = []string{"guild_id", "local_id"}
 )
 

--- a/customcommands/schema.go
+++ b/customcommands/schema.go
@@ -61,6 +61,10 @@ ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS disabled BOOLEAN NOT NULL D
 `, `
 ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS trigger_on_edit BOOLEAN NOT NULL DEFAULT false;
 `, `
+ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS public_id TEXT NOT NULL DEFAULT '';
+`, `
+CREATE INDEX IF NOT EXISTS custom_commands_public_id_idx ON custom_commands(public_id);
+`, ` 
 CREATE TABLE IF NOT EXISTS templates_user_database (
 	id BIGSERIAL PRIMARY KEY,
 

--- a/customcommands/schema.go
+++ b/customcommands/schema.go
@@ -64,7 +64,7 @@ ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS trigger_on_edit BOOLEAN NOT
 ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS public_id TEXT NOT NULL DEFAULT '';
 `, `
 CREATE INDEX IF NOT EXISTS custom_commands_public_id_idx ON custom_commands(public_id);
-`, ` 
+`, `
 CREATE TABLE IF NOT EXISTS templates_user_database (
 	id BIGSERIAL PRIMARY KEY,
 

--- a/customcommands/schema.go
+++ b/customcommands/schema.go
@@ -65,6 +65,8 @@ ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS public_id TEXT NOT NULL DEF
 `, `
 CREATE INDEX IF NOT EXISTS custom_commands_public_id_idx ON custom_commands(public_id);
 `, `
+ALTER TABLE custom_commands ADD COLUMN IF NOT EXISTS import_count INT NOT NULL DEFAULT 0;
+`, `
 CREATE TABLE IF NOT EXISTS templates_user_database (
 	id BIGSERIAL PRIMARY KEY,
 

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -554,20 +554,94 @@ func handleUpdateAndRunNow(w http.ResponseWriter, r *http.Request) (web.Template
 func handleUpdateAndShare(w http.ResponseWriter, r *http.Request) (web.TemplateData, error) {
 	ctx := r.Context()
 	activeGuild, templateData := web.GetBaseCPContextData(ctx)
-	cc := templateData["CC"].(*models.CustomCommand)
-	if cc.PublicID == "" {
+
+	cmdEdit := ctx.Value(common.ContextKeyParsedForm).(*CustomCommand)
+	cmdSaved, err := models.FindCustomCommandG(context.Background(), activeGuild.ID, int64(cmdEdit.ID))
+	if cmdSaved.Disabled == true && cmdEdit.ToDBModel().Disabled == false {
+		c, err := models.CustomCommands(qm.Where("guild_id = ? and disabled = false", activeGuild.ID)).CountG(ctx)
+		if err != nil {
+			return templateData, err
+		}
+		if int(c) >= MaxCommandsForContext(ctx) {
+			return templateData, web.NewPublicError(fmt.Sprintf("Max %d enabled custom commands allowed (or %d for premium servers)", MaxCommands, MaxCommandsPremium))
+		}
+	}
+
+	// ensure that the group specified is owned by this guild
+	if cmdEdit.GroupID != 0 {
+		c, err := models.CustomCommandGroups(qm.Where("guild_id = ? AND id = ?", activeGuild.ID, cmdEdit.GroupID)).CountG(ctx)
+		if err != nil {
+			return templateData, err
+		}
+
+		if c < 1 {
+			return templateData.AddAlerts(web.ErrorAlert("Unknown group")), nil
+		}
+	}
+
+	if !premium.ContextPremium(ctx) && cmdEdit.TriggerOnEdit {
+		return templateData.AddAlerts(web.ErrorAlert("`Trigger on edits` is a premium feature, your command wasn't saved, please save again after disabling `Trigger on edits`")), nil
+	}
+
+	dbModel := cmdEdit.ToDBModel()
+
+	templateData["CurrentGroupID"] = dbModel.GroupID.Int64
+
+	dbModel.GuildID = activeGuild.ID
+	dbModel.LocalID = cmdEdit.ID
+	dbModel.TriggerType = int(triggerTypeFromForm(cmdEdit.TriggerTypeForm))
+	// check low interval limits
+	if dbModel.TriggerType == int(CommandTriggerInterval) && dbModel.TimeTriggerInterval <= 10 {
+		if dbModel.TimeTriggerInterval < 5 {
+			dbModel.TimeTriggerInterval = 5
+		}
+
+		ok, err := checkIntervalLimits(ctx, activeGuild.ID, dbModel.LocalID, templateData)
+		if err != nil || !ok {
+			return templateData, err
+		}
+	}
+
+	if cmdSaved.PublicID == "" {
 		hash := sha1.New()
 		io.WriteString(hash, strconv.FormatInt(activeGuild.ID, 10))
 		io.WriteString(hash, strconv.FormatInt(time.Now().Unix(), 10))
 		fullHash := hash.Sum(nil)
 		truncatedHash := fullHash[:5]
 		truncatedHash = addCharIfCollides(ctx, fullHash, truncatedHash)
-		cc.PublicID = string(truncatedHash)
-		cc.Public = true
-		templateData["PublicLink"] = getPublicLink(cc)
-		r.WithContext(context.WithValue(ctx, common.ContextKeyTemplateData, templateData))
+		dbModel.PublicID = string(truncatedHash)
+		dbModel.Public = true
+		templateData["PublicLink"] = getPublicLink(dbModel)
 	}
-	return handleUpdateCommand(w, r)
+
+	_, err = dbModel.UpdateG(ctx, boil.Blacklist("last_run", "next_run", "local_id", "guild_id", "last_error", "last_error_time", "run_count", "import_count"))
+	if err != nil {
+		logger.Error(err)
+		return templateData, nil
+	}
+
+	// create, update or remove the next run time and scheduled event
+	if dbModel.TriggerType == int(CommandTriggerInterval) {
+		// need the last run time
+		fullModel, err := models.CustomCommands(qm.Where("guild_id = ? AND local_id = ?", activeGuild.ID, dbModel.LocalID)).OneG(ctx)
+		if err != nil {
+			web.CtxLogger(ctx).WithError(err).Error("failed retrieving full model")
+		} else {
+			err = UpdateCommandNextRunTime(fullModel, true, true)
+		}
+	} else {
+		err = DelNextRunEvent(activeGuild.ID, dbModel.LocalID)
+	}
+
+	if err != nil {
+		web.CtxLogger(ctx).WithError(err).WithField("guild", dbModel.GuildID).Error("failed updating next custom command run time")
+	}
+
+	go cplogs.RetryAddEntry(web.NewLogEntryFromContext(r.Context(), panelLogKeyUpdatedCommand, &cplogs.Param{Type: cplogs.ParamTypeInt, Value: dbModel.LocalID}))
+
+	pubsub.EvictCacheSet(cachedCommandsMessage, activeGuild.ID)
+
+	return templateData, err
 }
 
 func addCharIfCollides(ctx context.Context, full, truncated []byte) []byte {

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -848,7 +848,7 @@ func updateTemplateWithCountData(count int, templateData web.TemplateData, ctx c
 func PublicCommandMW(inner http.Handler) http.Handler {
 	mw := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		activeGuild, templateData := web.GetBaseCPContextData(ctx)
+		_, templateData := web.GetBaseCPContextData(ctx)
 		publicID := pat.Param(r, "cmd")
 		cc, err := models.CustomCommands(
 			models.CustomCommandWhere.PublicID.EQ(publicID)).OneG(r.Context())
@@ -859,7 +859,7 @@ func PublicCommandMW(inner http.Handler) http.Handler {
 		}
 
 		if read, _ := web.IsAdminRequest(ctx, r); read {
-			http.Redirect(w, r, fmt.Sprintf("/manage/%d/customcommands/commands/%d/", activeGuild.ID, cc.LocalID), http.StatusSeeOther)
+			http.Redirect(w, r, fmt.Sprintf("/manage/%d/customcommands/commands/%d/", cc.GuildID, cc.LocalID), http.StatusSeeOther)
 		} else {
 			if cc.Public {
 				templateData["PublicAccess"] = true
@@ -869,7 +869,7 @@ func PublicCommandMW(inner http.Handler) http.Handler {
 					strTriggerTypes[int(k)] = v
 				}
 				templateData["CCTriggerTypes"] = strTriggerTypes
-				templateData["CommandPrefix"], _ = prfx.GetCommandPrefixRedis(activeGuild.ID)
+				templateData["CommandPrefix"], _ = prfx.GetCommandPrefixRedis(cc.GuildID)
 
 				// retrieve the cc's page
 				defer func() { inner.ServeHTTP(w, r) }()

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -277,7 +277,7 @@ func handleGetCommand(w http.ResponseWriter, r *http.Request) (web.TemplateData,
 	templateData["IsGuildPremium"] = premium.ContextPremium(r.Context())
 	templateData["PublicLink"] = getPublicLink(cc)
 
-	return serveGroupSelected(r, templateData, cc.GroupID.Int64, activeGuild.ID)
+	return serveGroupSelected(r, templateData, cc.GroupID.Int64, cc.GuildID)
 }
 
 func getPublicLink(cc *models.CustomCommand) string {

--- a/customcommands/web.go
+++ b/customcommands/web.go
@@ -141,13 +141,13 @@ func (p *Plugin) InitWeb() {
 
 	shortlinkSubMux.Use(func(inner http.Handler) http.Handler {
 		h := func(w http.ResponseWriter, r *http.Request) {
-			g, templateData := web.GetBaseCPContextData(r.Context())
+			_, templateData := web.GetBaseCPContextData(r.Context())
 			strTriggerTypes := map[int]string{}
 			for k, v := range triggerStrings {
 				strTriggerTypes[int(k)] = v
 			}
 			templateData["CCTriggerTypes"] = strTriggerTypes
-			templateData["CommandPrefix"], _ = prfx.GetCommandPrefixRedis(g.ID)
+			templateData["CommandPrefix"] = prfx.DefaultCommandPrefix()
 
 			inner.ServeHTTP(w, r)
 		}


### PR DESCRIPTION
Sharing links are now short. They follow the format baseURL/cc/publicID
where publicID is a sha1 hash of guild ID + local ID, salted with time of
public link creation, base64 encoded, and truncated as small as it can
get without colliding with an existing command's public ID (minimum 5
characters.)

Signed-off-by: SoggySaussages <vmdmaharaj@gmail.com>